### PR TITLE
chore: add packages rules for mongoose and lab

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,8 @@
       "packageNames": [
         "hoek",
         "rejoice",
-        "scooter"
+        "scooter",
+        "mongoose"
       ],
       "allowedVersions": "<5"
     },
@@ -22,6 +23,10 @@
     {
       "packageNames": ["newrelic"],
       "allowedVersions": "<=4.2"
+    },
+    {
+      "packageNames": ["lab"],
+      "allowedVersions": "<15"
     }
   ]
 }


### PR DESCRIPTION
These were in my previous "legacy" Renovate config, and likely should be added back to this one. 

Lab >= 15 removes the `done` callback, requiring a _lot_ of refactoring to fix. 
Mongoose - I'm not sure, but I had tested and added each of the packages manually, so it's likely needed. Will confirm why.