### PR TITLE
chore: enable newrelic upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,10 +18,6 @@
     {
       "packageNames": ["good"],
       "allowedVersions": "<8"
-    },
-    {
-      "packageNames": ["newrelic"],
-      "allowedVersions": "<=4.2"
     }
   ]
 }


### PR DESCRIPTION
Enables newrelic v5+ upgrades.
The perf regression has been fixed and this is required for monitoring