### PR TITLE
Update config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,7 +44,7 @@
       "allowedVersions": "<9"
     },
     {
-      "packageNames": ["@pagerinc/hapi-auth-armor"],
+      "packageNames": ["@pagerinc/hapi-redis"],
       "allowedVersions": "<2"
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,38 @@
     {
       "packageNames": ["good"],
       "allowedVersions": "<8"
+    },
+    {
+      "packageNames": ["h2o2"],
+      "allowedVersions": "<6"
+    },
+    {
+      "packageNames": ["confidence"],
+      "allowedVersions": "<4"
+    },
+    {
+      "packageNames": ["hapi-emitter"],
+      "allowedVersions": "<3"
+    },
+    {
+      "packageNames": ["@pagerinc/hapi-auth-armor"],
+      "allowedVersions": "<5"
+    },
+    {
+      "packageNames": ["@pagerinc/hapi-bunny"],
+      "allowedVersions": "<5"
+    },
+    {
+      "packageNames": ["@pagerinc/hapi-mongo"],
+      "allowedVersions": "<6"
+    },
+    {
+      "packageNames": ["@pagerinc/hapi-raven"],
+      "allowedVersions": "<9"
+    },
+    {
+      "packageNames": ["@pagerinc/hapi-auth-armor"],
+      "allowedVersions": "<2"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,7 @@
     },
     {
       "packageNames": ["h2o2"],
-      "allowedVersions": "<6"
+      "allowedVersions": "<7"
     },
     {
       "packageNames": ["confidence"],

--- a/renovate.json
+++ b/renovate.json
@@ -24,10 +24,6 @@
       "allowedVersions": "<7"
     },
     {
-      "packageNames": ["confidence"],
-      "allowedVersions": "<4"
-    },
-    {
       "packageNames": ["hapi-emitter"],
       "allowedVersions": "<3"
     },


### PR DESCRIPTION
Add limitations for next packages:

|Package name|Version|Changelog|
|---|---|---|
|[h2o2](https://github.com/hapijs/h2o2)|<7|N/A (you could install `h2o2@6.1.0` and `h2o2@7.0.0` and check `register` signature ```cat node_modules/h2o2/lib/index.js | grep register```)|
|[hapi-emitter](https://github.com/cilindrox/hapi-emitter)|<3|N/A (you could install `hapi-emitter@1.0.0` and `hapi-emitter@3.0.0` and check `register` signature ```cat node_modules/hapi-emitter/lib/index.js | grep register```)|
|[@pagerinc/hapi-auth-armor](https://github.com/pagerinc/hapi-auth-armor)|<5|[Changelog](https://github.com/pagerinc/hapi-auth-armor/compare/v4.3.0-rc.2..5.1.0)|
|[@pagerinc/hapi-bunny](https://github.com/pagerinc/hapi-bunny)|<5|[Changelog](https://github.com/pagerinc/hapi-bunny/compare/f35dc93...67d54f2)|
|[@pagerinc/hapi-mongo](https://github.com/pagerinc/hapi-mongo)|<6|[Changelog](https://github.com/pagerinc/hapi-mongo/compare/v5.0.2-rc.1..v6.1.0)|
|[@pagerinc/hapi-raven](https://github.com/pagerinc/hapi-raven)|<9|N/A (you could install `@pager/hapi-raven@8.0.0` and `@pager/hapi-raven@9.0.0` and check `register` signature ```cat node_modules/@pager/hapi-raven/lib/index.js | grep register```)|
|[@pagerinc/hapi-redis](https://github.com/pagerinc/hapi-redis)|<2|[Changelog](https://github.com/pagerinc/hapi-redis/compare/v1.2.0..v2.0.0)|